### PR TITLE
refactor : PR#17_revision

### DIFF
--- a/everytime/everytime/settings.py
+++ b/everytime/everytime/settings.py
@@ -140,7 +140,7 @@ else:
             'PORT': 3306,
             'NAME': 'team11_db',
             'USER': 'team11_db_user',
-            'PASSWORD': 'secret1234',
+            'PASSWORD': 'secretkey1234',
         }
     }
 

--- a/everytime/user/serializers.py
+++ b/everytime/user/serializers.py
@@ -36,39 +36,23 @@ class UserCreateSerializer(serializers.ModelSerializer):
         )
 
     def validate(self, data):
-        university_name = data.get('university')
-        try:
-            university = University.objects.get(name = university_name)
-        except:
-            raise serializers.ValidationError("등록되지 않은 학교명입니다.")
-        user_id = data.get('user_id')
-        name = data.get('name')
-        email = data.get('email')
-        nickname = data.get('nickname')
-        password = data.get('password')
-        admission_year = data.get('admission_year')
-        if user_id == None:
-            raise serializers.ValidationError("아이디를 입력해주세요.")
-        if password == None:
-            raise serializers.ValidationError("비밀번호를 입력해주세요.")
-        if name == None:
-            raise serializers.ValidationError("이름을 입력해주세요.")
-        if email == None:
-            raise serializers.ValidationError("이메일을 입력해주세요.")
-        if nickname == None:
-            raise serializers.ValidationError("닉네임을 입력해주세요.")
-        if admission_year == None:
-            raise serializers.ValidationError("학년을 입력해주세요.")
+        # create 시에만 작동. update할때는 작동하지 않음.
+        if not self.instance : 
+            university_name = data.get('university')
+            try:
+                university = University.objects.get(name = university_name)
+            except:
+                raise serializers.ValidationError("등록되지 않은 학교명입니다.")
+
         return data
     
-    def update(self, instance, validated_data):
-        instance.email = validated_data.get('email')
-        instance.nickname = validated_data.get('nickname')
-        instance.password = validated_data.get('password')
-        instance.is_active = validated_data.get('is_active')
-        instance.save()
-        return instance
-
+    # def update(self, instance, validated_data):
+    #     instance.email = validated_data.get('email')
+    #     instance.nickname = validated_data.get('nickname')
+    #     instance.password = validated_data.get('password')
+    #     instance.is_active = validated_data.get('is_active')
+    #     instance.save()
+    #     return instance
 
     def create(self, validated_data):
         admission_year = validated_data.pop('admission_year')

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -61,7 +61,16 @@ class UserViewSet(viewsets.GenericViewSet):
 
     def list(self, request, pk=None):
         user = request.user
-        return Response({"id" : user.user_id, "name" : user.name, "nickname" : user.nickname, "university" : user.university.name, "admissionYear" : user.admission_year}, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "user_id" : user.user_id, 
+                "name" : user.name, 
+                "email" : user.email, 
+                "admission_year" : user.admission_year, 
+                "nickname" : user.nickname, 
+                "university" : user.university.name
+            }
+            ,status=status.HTTP_200_OK)
 
 class UserDeleteViewset(viewsets.GenericViewSet):
     permission_classes = (permissions.IsAuthenticated, )
@@ -71,14 +80,6 @@ class UserDeleteViewset(viewsets.GenericViewSet):
         word = request.query_params.get('password')
         user = request.user
         data = request.data.copy()
-        data['user_id'] = user.user_id
-        data['name'] = user.name
-        data['email'] = user.email
-        university = user.university.name
-        data['university'] = university
-        data['nickname'] = user.nickname
-        data['password'] = user.password
-        data['admission_year'] = user.admission_year
         data['is_active'] = False
         if not word:
             return Response({"error" : "wrong_password", "detail" : "비밀번호를 입력해주세요."}, status= status.HTTP_400_BAD_REQUEST)
@@ -141,15 +142,7 @@ class UserUpdateEmailView(viewsets.GenericViewSet):
     serializer_class = UserCreateSerializer
     def put(self, request, pk = None):
         user = request.user
-        data = request.query_params.copy()
-        data['user_id'] = user.user_id
-        data['name'] = user.name
-        university = user.university.name
-        data['university'] = university
-        data['nickname'] = user.nickname
-        data['password'] = user.password
-        data['admission_year'] = user.admission_year
-        data['is_active'] = user.is_active
+        data = request.data.copy()
         if data.get('email') == None:
             return Response({"error" : "이메일을 입력해주세요."}, status = status.HTTP_404_NOT_FOUND)
         serializer = self.get_serializer(user, data=data, partial = True)
@@ -160,24 +153,16 @@ class UserUpdateEmailView(viewsets.GenericViewSet):
             return Response({"success" : False, "detail" : "이미 사용중인 이메일입니다."}, status= status.HTTP_400_BAD_REQUEST)
         return Response({"success" : True}, status = status.HTTP_200_OK)
 
-    def list(self, request, pk=None):
-        email = request.query_params.get('email')
-        return Response({"detail" : email}, status = status.HTTP_200_OK)
+    # def list(self, request, pk=None):
+    #     email = request.query_params.get('email')
+    #     return Response({"detail" : email}, status = status.HTTP_200_OK)
 
 class UserUpdateNicknameView(viewsets.GenericViewSet):
     permission_classes = (permissions.IsAuthenticated, )
     serializer_class = UserCreateSerializer
     def put(self, request, pk = None):
         user = request.user
-        data = request.query_params.copy()
-        data['user_id'] = user.user_id
-        data['name'] = user.name
-        university = user.university.name
-        data['university'] = university
-        data['email'] = user.email
-        data['password'] = user.password
-        data['admission_year'] = user.admission_year
-        data['is_active'] = user.is_active
+        data = request.data.copy()
         if data.get('nickname') == None:
             return Response({"error" : "닉네임을 입력해주세요."}, status = status.HTTP_404_NOT_FOUND)
         serializer = self.get_serializer(user, data=data, partial = True)
@@ -189,7 +174,7 @@ class UserUpdateNicknameView(viewsets.GenericViewSet):
         return Response({"success" : True}, status = status.HTTP_200_OK)
 
     def list(self, request, pk=None):
-        nickname = request.query_params.get('nickname')
+        nickname = request.data.get('nickname')
         return Response({"detail" : nickname}, status = status.HTTP_200_OK)
 
 class UserUpdatePasswordView(viewsets.GenericViewSet):
@@ -197,8 +182,7 @@ class UserUpdatePasswordView(viewsets.GenericViewSet):
     serializer_class = UserCreateSerializer
     def put(self, request, pk = None):
         user = request.user
-        data = request.query_params
-
+        data = request.data.copy()
         if data.get('password') == None:
             return Response({"error" : "비밀번호를 입력해주세요."}, status = status.HTTP_404_NOT_FOUND)
         try:
@@ -210,5 +194,5 @@ class UserUpdatePasswordView(viewsets.GenericViewSet):
         return Response({"success" : True}, status = status.HTTP_200_OK)
 
     def list(self, request, pk=None):
-        password = request.query_params.get('password')
+        password = request.data.get('password')
         return Response({"detail" : password}, status = status.HTTP_200_OK)

--- a/scripts/test_case.txt
+++ b/scripts/test_case.txt
@@ -1,0 +1,20 @@
+POST api/v1/register/university/
+{
+    "name": "서울대학교",
+    "email": "snu.ac.kr"
+}
+{
+    "name": "연세대학교",
+    "email": "yonsei.ac.kr"
+}
+
+POST api/v1/register/
+{
+    "user_id": "esc5221",
+    "name": "최병욱",
+    "email": "esc5221@snu.ac.kr",
+    "nickname": "코코넛",
+    "password": "secret1234",
+    "university": "서울대학교",
+    "admission_year": "2017"
+}


### PR DESCRIPTION
[PR#17](https://github.com/wafflestudio19-5/team11-server/pull/17)에 대한 수정 PR입니다. 
- my/email/ 및 2개의 API가 바꿀 데이터를 받는 방법을  query_param에서 data로 변경
- View에서 data 받는 부분 간소화 (partial 이용)
- UserUpdate*View 데이터 가져오는 방식 query_param에서 body로 변경 (API에 따름)
- UserCreateSerializer.validate 함수 간소화
- settings.py local mysql 비밀번호 변경